### PR TITLE
12 add testrunner presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /venv/
 /nuke_dependencies/
 *.pyc
+runners.json

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from nuke_test_runner.configuration import find_configuration
+
+nuke_test = pytest.mark.skipif(not find_configuration(Path(os.getcwd())))
+
+
+def pytest_runtest_setup(item) -> None:
+    """Hook for skipping/manipulating tests before execution.
+
+    This is called by pytest for each test item.
+    """
+    _check_nuke_marker(item)
+
+
+def _check_nuke_marker(item):
+    """Mark a tests as skip if the nuke marker is set but no runner config."""
+    has_nuke_marker = next(item.iter_markers("nuke"), None)
+    # TODO [everyone]: We are going to search the config for each test with a "nuke" marker.
+    #  This could lead to some performance penalties. On the other hand allows this a per test
+    #  runner. We might need this.
+    if has_nuke_marker and not find_configuration(Path(item.path)):
+        pytest.skip("Test requires a setup runners.json to be executed.")

--- a/Tests/nuke_test_runner/test_configuration.py
+++ b/Tests/nuke_test_runner/test_configuration.py
@@ -87,7 +87,7 @@ def test_config_file_does_not_exist(
     "start_path",
     [".", "sub1/sub2/", "sub1/test.py", "test.py", "sub1/sub2/test.py"],
 )
-def test_find_config(start_path:str) -> None:
+def test_find_config(start_path: str) -> None:
     """Test that the config can be found in the parent folder."""
     with TemporaryDirectory() as tmp_dir:
         cwd = Path(tmp_dir)
@@ -102,3 +102,8 @@ def test_find_config(start_path:str) -> None:
         config.write_text("config")
 
         assert find_configuration(test_file) == config
+
+
+def test_find_config_root_dir_loop() -> None:
+    """Test that the find config won't loop endlessly if it reaches the root."""
+    assert find_configuration(Path(Path(__file__).anchor)) is None

--- a/Tests/nuke_test_runner/test_configuration.py
+++ b/Tests/nuke_test_runner/test_configuration.py
@@ -1,0 +1,72 @@
+"""Tests for loading runners from configurations."""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nuke_test_runner.configuration import load_runners
+from nuke_test_runner.runner import Runner, RunnerException
+
+
+@pytest.fixture()
+def runner_mock() -> MagicMock:
+    """Get a mock of the runner."""
+    with patch("nuke_test_runner.configuration.Runner", spec=Runner) as runner:
+        yield runner
+
+
+@pytest.fixture()
+def config_file() -> MagicMock:
+    """Get a mock for the config file.
+
+    Use "config_file.read_text.return_value" to configure the content of the config file.
+    """
+    return MagicMock(spec=Path)
+
+
+def test_load_single_runner(
+    runner_mock: MagicMock, config_file: MagicMock
+) -> None:
+    """Test that a runner is loaded from a single config."""
+    config = {"test": {"exe": "test.exe", "args": ["-test"]}}
+    config_file.read_text.return_value = json.dumps(config)
+
+    runner = load_runners(config_file)
+
+    runner_mock.assert_called_once_with("test.exe", ["-test"])
+    assert (
+        runner["test"] is runner_mock.return_value
+    ), "Runner was not added to the output"
+
+
+@pytest.mark.parametrize(
+    "names", [("nuke", "nukeX"), ("nuke-nc", "n", "studio")]
+)
+def test_load_multiple_runners(
+    runner_mock: MagicMock, config_file: MagicMock, names: tuple[str]
+) -> None:
+    """Test that multiple runners can be loaded from the config."""
+    config = {name: {"exe": name, "args": [name]} for name in names}
+    config_file.read_text.return_value = json.dumps(config)
+
+    runners = load_runners(config_file)
+
+    for name in names:
+        assert runners[name]
+        runner_mock.assert_any_call(name, [name])
+
+
+def test_load_runners_with_errors(runner_mock: MagicMock, config_file: MagicMock) -> None:
+    """Test that wrongly configured runners are not preventing other runners from loading."""
+    names = ["correct", "mistake", "correct2"]
+    config = {name: {"exe": name, "args": [name]} for name in names}
+    config_file.read_text.return_value = json.dumps(config)
+    runner_mock.side_effect = [None, RunnerException("Test exception"), None]
+
+    runners = load_runners(config_file)
+
+    assert "correct" in runners
+    assert "correct2" in runners
+    assert "mistake" not in runners
+

--- a/Tests/nuke_test_runner/test_configuration.py
+++ b/Tests/nuke_test_runner/test_configuration.py
@@ -57,7 +57,9 @@ def test_load_multiple_runners(
         runner_mock.assert_any_call(name, [name])
 
 
-def test_load_runners_with_errors(runner_mock: MagicMock, config_file: MagicMock) -> None:
+def test_load_runners_with_errors(
+    runner_mock: MagicMock, config_file: MagicMock
+) -> None:
     """Test that wrongly configured runners are not preventing other runners from loading."""
     names = ["correct", "mistake", "correct2"]
     config = {name: {"exe": name, "args": [name]} for name in names}
@@ -70,3 +72,11 @@ def test_load_runners_with_errors(runner_mock: MagicMock, config_file: MagicMock
     assert "correct2" in runners
     assert "mistake" not in runners
 
+
+def test_config_file_does_not_exist(
+    runner_mock: MagicMock, config_file: MagicMock
+) -> None:
+    """Test that an empty dictionary is returned if the files does not exist."""
+    config_file.exists.return_value = False
+
+    assert load_runners(config_file) == {}

--- a/Tests/nuke_test_runner/test_run_tests.py
+++ b/Tests/nuke_test_runner/test_run_tests.py
@@ -99,7 +99,7 @@ def test_commandline(test: str, code: int) -> None:
 @pytest.mark.parametrize(
     ("args", "message"),
     [
-        ([], "Missing argument 'EXECUTABLE'"),
+        ([], "Missing argument 'INTERPRETER'"),
         (["."], "Missing argument 'TESTS'"),
     ],
 )

--- a/Tests/nuke_test_runner/test_run_tests.py
+++ b/Tests/nuke_test_runner/test_run_tests.py
@@ -85,13 +85,11 @@ def test_commandline(test: str, code: int) -> None:
     """Test that the script can be executed from the commandline."""
     run_file = inspect.getfile(run_tests)
     call = [sys.executable, run_file]
-    reference_test = (
-        constants.NUKE_TESTING_FOLDER / "tests" / f"reference_tests.py::{test}"
-    )
-    # FIXME [lukas] replace a static path of the nuke executable.
-    call.extend(
-        [r"C:\Program Files\Nuke15.0v3\Nuke15.0.exe", str(reference_test)]
-    )
+    tests_folder = constants.NUKE_TESTING_FOLDER / "tests"
+    reference_test = tests_folder / f"reference_tests.py::{test}"
+
+    call.extend(["nuke", str(reference_test)])
+
     print(call)
     process = subprocess.run(call, stdout=subprocess.PIPE)
     # Used for debugging subprocess output:

--- a/Tests/nuke_test_runner/test_run_tests.py
+++ b/Tests/nuke_test_runner/test_run_tests.py
@@ -26,14 +26,6 @@ def sys_exit() -> MagicMock:
         yield good_bye
 
 
-@pytest.fixture(autouse=True)
-def load_config() -> MagicMock:
-    """Mock the configuration loading."""
-    with patch("run_tests.load_runners") as config:
-        config.return_value = {}
-        yield config
-
-
 def test_create_runner(runner: MagicMock) -> None:
     """Test that a runner instance is created from the user path."""
     run_tests("nuke_path", ".")
@@ -59,6 +51,7 @@ def test_exit_code_forwarding(runner: MagicMock, sys_exit: MagicMock) -> None:
     sys_exit.assert_called_with(1928)
 
 
+@patch("run_tests.load_runners")
 def test_config_file_loaded(load_config: MagicMock, runner: MagicMock) -> None:
     """Test that runners from the config are prioritized."""
     my_runner = MagicMock(spec=Runner)

--- a/Tests/nuke_test_runner/test_run_tests.py
+++ b/Tests/nuke_test_runner/test_run_tests.py
@@ -76,7 +76,11 @@ def test_commandline(test: str, code: int) -> None:
 
 
 @pytest.mark.parametrize(
-    ("args", "message"), [([], "Missing argument 'EXECUTABLE'"), (["."], "Missing argument 'TESTS'")]
+    ("args", "message"),
+    [
+        ([], "Missing argument 'EXECUTABLE'"),
+        (["."], "Missing argument 'TESTS'"),
+    ],
 )
 def test_commandline_missing_parameters(args: list[str], message: str) -> None:
     """Test that the nuke path and the tests are required."""

--- a/datamodel/constants.py
+++ b/datamodel/constants.py
@@ -6,3 +6,5 @@ NUKE_DEPENDENCY_FOLDER = NUKE_TESTING_FOLDER / "nuke_dependencies"
 REQUIREMENT_TXT = NUKE_TESTING_FOLDER / "requirements.txt"
 
 RUN_TESTS_SCRIPT = NUKE_TESTING_FOLDER / "nuke_test_runner" / "run_pytest.py"
+
+RUNNER_CONFIGURATION_FILE = NUKE_TESTING_FOLDER / "runners.json"

--- a/datamodel/constants.py
+++ b/datamodel/constants.py
@@ -6,5 +6,3 @@ NUKE_DEPENDENCY_FOLDER = NUKE_TESTING_FOLDER / "nuke_dependencies"
 REQUIREMENT_TXT = NUKE_TESTING_FOLDER / "requirements.txt"
 
 RUN_TESTS_SCRIPT = NUKE_TESTING_FOLDER / "nuke_test_runner" / "run_pytest.py"
-
-RUNNER_CONFIGURATION_FILE = NUKE_TESTING_FOLDER / "runners.json"

--- a/nuke_test_runner/configuration.py
+++ b/nuke_test_runner/configuration.py
@@ -11,6 +11,7 @@ Runner configuration is expected to be in the format:
 """
 from __future__ import annotations
 
+import itertools
 import json
 from contextlib import suppress
 from pathlib import Path
@@ -60,9 +61,9 @@ def find_configuration(start_path: Path) -> Path | None:
     else:
         path = start_path
 
-    while path.parent:
-        config = path / "runners.json"
+    for parent in itertools.chain([path], path.parents):
+        config = parent / "runners.json"
         if config.exists():
             return config
-        path = path.parent
+
     return None

--- a/nuke_test_runner/configuration.py
+++ b/nuke_test_runner/configuration.py
@@ -9,6 +9,8 @@ Runner configuration is expected to be in the format:
     }
 }
 """
+from __future__ import annotations
+
 import json
 from contextlib import suppress
 from pathlib import Path
@@ -39,3 +41,28 @@ def load_runners(filepath: Path) -> dict[str, Runner]:
             result[name] = Runner(config["exe"], config["args"])
 
     return result
+
+
+def find_configuration(start_path: Path) -> Path | None:
+    """Find a configuration file that is part of the current test.
+
+    This will return the first configuration that is found.
+    It will traverse the directories up to find a "runners.json".
+
+    Args:
+        start_path: the starting directory/file where the search begins.
+
+    Returns:
+        The found "runners.json" or None.
+    """
+    if start_path.is_file():
+        path = start_path.parent
+    else:
+        path = start_path
+
+    while path.parent:
+        config = path / "runners.json"
+        if config.exists():
+            return config
+        path = path.parent
+    return None

--- a/nuke_test_runner/configuration.py
+++ b/nuke_test_runner/configuration.py
@@ -1,0 +1,35 @@
+"""Runner configuration package.
+
+This is used to load test runners from the configuration file.
+Runner configuration is expected to be in the format:
+{
+    runner_name: {
+        "exe": path to nuke,
+        "args": [list of arguments for nuke]
+    }
+}
+"""
+import json
+from contextlib import suppress
+from pathlib import Path
+
+from nuke_test_runner.runner import Runner, RunnerException
+
+
+def load_runners(filepath: Path) -> dict[str, Runner]:
+    """Load all runners specified in the config file.
+
+    Args:
+        filepath: the config filepath.
+
+    Returns:
+        dictionary of runner name and loaded runner.
+    """
+    data = json.loads(filepath.read_text())
+
+    result = {}
+    for name, config in data.items():
+        with suppress(RunnerException):
+            result[name] = Runner(config["exe"], config["args"])
+
+    return result

--- a/nuke_test_runner/configuration.py
+++ b/nuke_test_runner/configuration.py
@@ -19,12 +19,18 @@ from nuke_test_runner.runner import Runner, RunnerException
 def load_runners(filepath: Path) -> dict[str, Runner]:
     """Load all runners specified in the config file.
 
+    Notes:
+        If the file does not exist, an empty dictionary will be returned.
+
     Args:
         filepath: the config filepath.
 
     Returns:
         dictionary of runner name and loaded runner.
     """
+    if not filepath.exists():
+        return {}
+
     data = json.loads(filepath.read_text())
 
     result = {}

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,8 +7,7 @@ from typing import NoReturn
 
 import click
 
-from datamodel.constants import RUNNER_CONFIGURATION_FILE
-from nuke_test_runner.configuration import load_runners
+from nuke_test_runner.configuration import load_runners, find_configuration
 from nuke_test_runner.runner import Runner
 
 
@@ -20,9 +19,13 @@ def run_tests(interpreter: str | Path, tests: str | Path) -> NoReturn:
         tests: path to the test file/folder.
     """
     runner = None
+
     if isinstance(interpreter, str):
-        runners = load_runners(RUNNER_CONFIGURATION_FILE)
-        runner = runners.get(interpreter)
+        search_start = Path(tests.split(":")[0])
+        config = find_configuration(search_start)
+        if config:
+            runners = load_runners(config)
+            runner = runners.get(interpreter)
 
     runner = runner or Runner(interpreter)
     sys.exit(runner.execute_tests(tests))

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,6 +7,8 @@ from typing import NoReturn
 
 import click
 
+from datamodel.constants import RUNNER_CONFIGURATION_FILE
+from nuke_test_runner.configuration import load_runners
 from nuke_test_runner.runner import Runner
 
 
@@ -17,7 +19,12 @@ def run_tests(executable: str | Path, tests: str | Path) -> NoReturn:
         executable: path to the nuke executable.
         tests: path to the test file/folder.
     """
-    runner = Runner(executable)
+    runner = None
+    if isinstance(executable, str):
+        runners = load_runners(RUNNER_CONFIGURATION_FILE)
+        runner = runners.get(executable)
+
+    runner = runner or Runner(executable)
     sys.exit(runner.execute_tests(tests))
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -34,6 +34,15 @@ def run_tests(interpreter: str | Path, tests: str | Path) -> NoReturn:
 def main(interpreter: str, tests: str) -> NoReturn:
     """Run the test files with nuke.
 
+    INTERPRETER is the filepath to the nuke executable.
+    If you provided a "runner.json" configuration,
+    you can also reference the runner by its configured name.
+
+    TESTS is the folder of file of the tests you want to execute.
+    Use the pytest folder/file.py::class::method notation to run single tests.
+    For further options consult the pytest documentation.
+    \f
+
     Args:
         interpreter: name of the configured interpreter or the path to the nuke executable.
         tests: path to the test/ test folder.

--- a/run_tests.py
+++ b/run_tests.py
@@ -12,34 +12,34 @@ from nuke_test_runner.configuration import load_runners
 from nuke_test_runner.runner import Runner
 
 
-def run_tests(executable: str | Path, tests: str | Path) -> NoReturn:
+def run_tests(interpreter: str | Path, tests: str | Path) -> NoReturn:
     """Run the tests.
 
     Args:
-        executable: path to the nuke executable.
+        interpreter: name of the configured interpreter or the path to the nuke executable.
         tests: path to the test file/folder.
     """
     runner = None
-    if isinstance(executable, str):
+    if isinstance(interpreter, str):
         runners = load_runners(RUNNER_CONFIGURATION_FILE)
-        runner = runners.get(executable)
+        runner = runners.get(interpreter)
 
-    runner = runner or Runner(executable)
+    runner = runner or Runner(interpreter)
     sys.exit(runner.execute_tests(tests))
 
 
 @click.command()
-@click.argument("executable", type=str)
+@click.argument("interpreter", type=str)
 @click.argument("tests", type=str)
-def main(executable: str, tests: str) -> NoReturn:
+def main(interpreter: str, tests: str) -> NoReturn:
     """Run the test files with nuke.
 
     Args:
-        executable: path to the nuke executable which will execute the tests.
+        interpreter: name of the configured interpreter or the path to the nuke executable.
         tests: path to the test/ test folder.
     """
-    run_tests(executable, tests)
+    run_tests(interpreter, tests)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add "runner.json" to the testrunner.
This makes it possible to configure different runners for different folder/projects.
E.g. you could define a nuke entry and switch the versions so you could execute different tests for different versions.