### PR TITLE
Fix windows path separation

### DIFF
--- a/src/nuketesting/_cli/run_pytest_bootstrapped.py
+++ b/src/nuketesting/_cli/run_pytest_bootstrapped.py
@@ -29,7 +29,7 @@ def _run_tests(packages_directory: str, test_directory: str, pytest_arguments: l
         test_directory: directory to run pytest on
         pytest_arguments: additional arguments to pass to pytest. For example -v for verbose, etc.
     """
-    for path in packages_directory.split(":"):
+    for path in packages_directory.split(";"):
         if not Path(path).is_dir():
             msg = f"Package directory does not exist: '{path}'."
             raise BootstrapError(msg)

--- a/src/nuketesting/_cli/runner.py
+++ b/src/nuketesting/_cli/runner.py
@@ -107,7 +107,7 @@ class Runner:
         """Get the PATH to the packages locations necessary for running tests."""
         packages_directory = Path(pytest.__file__).parent.parent
         testrunner_directory = Path(nuketesting.__file__).parent.parent
-        return f"{packages_directory!s}:{testrunner_directory!s}"
+        return f"{packages_directory!s};{testrunner_directory!s}"
 
     def _execute_in_nuke(self, test_path: str | Path) -> int:
         """Execute the tests using the Nuke interpreter.

--- a/src/nuketesting/_cli/runner.py
+++ b/src/nuketesting/_cli/runner.py
@@ -47,9 +47,7 @@ class Runner:
 
     def _clean_executable_args(self) -> None:
         """Check and clean the executable args."""
-        if "-t" in self._executable_args:
-            index = self._executable_args.index("-t")
-            self._executable_args.pop(index)
+        self._executable_args = [arg for arg in self._executable_args if arg and arg != "-t"]
 
     @staticmethod
     def _check_nuke_executable(executable: Path) -> None:

--- a/tests/test_src/test_nuketesting/_cli/test_run_pytest_bootstrapped.py
+++ b/tests/test_src/test_nuketesting/_cli/test_run_pytest_bootstrapped.py
@@ -6,8 +6,9 @@ import pytest
 from nuketesting._cli.run_pytest_bootstrapped import BootstrapError, _parse_args, _run_tests
 
 
-@patch("nuketesting._cli.run_pytest_bootstrapped.Path.is_dir", return_value=True)
-@patch("pytest.main", return_value=0)
+# noinspection PyUnreachableCode
+@patch("nuketesting._cli.run_pytest_bootstrapped.Path.is_dir", MagicMock(return_value=True))
+@patch("pytest.main", MagicMock(return_value=0))
 @pytest.mark.parametrize(
     "test_directories",
     [
@@ -15,9 +16,9 @@ from nuketesting._cli.run_pytest_bootstrapped import BootstrapError, _parse_args
         ["first/dir", "second/dir", "third/directory"],
     ],
 )
-def test__run_tests_path_insertion(is_dir_mock, pytest_mock: MagicMock, test_directories: list[str]) -> None:
+def test__run_tests_path_insertion(test_directories: list[str]) -> None:
     """Test path insertion to add both nuketesting directory and pytest."""
-    test_directories_combined = ":".join(test_directories)
+    test_directories_combined = ";".join(test_directories)
 
     with patch("nuketesting._cli.run_pytest_bootstrapped.sys") as sys_mock:
         _run_tests(test_directories_combined, "", [])
@@ -27,6 +28,7 @@ def test__run_tests_path_insertion(is_dir_mock, pytest_mock: MagicMock, test_dir
         assert expected_call in sys_mock.path.append.call_args_list
 
 
+# noinspection PyUnreachableCode
 @patch("nuketesting._cli.run_pytest_bootstrapped.sys")
 @pytest.mark.parametrize(
     ("test_directory", "test_pytest_args", "expected_arguments"),
@@ -49,6 +51,7 @@ def test__run_tests_pytest_args(
     pytest_mock.assert_called_once_with(expected_arguments)
 
 
+# noinspection PyUnreachableCode
 def test__run_tests_forward_exit_code() -> None:
     """Test the forwarding of the exit code of the pytest run."""
     with patch("nuketesting._cli.run_pytest_bootstrapped.sys") as sys_mock, patch("pytest.main", return_value=1):


### PR DESCRIPTION
The package and pytest paths are split by a colon. It was very obvious once reading the error message file "C" does not exist XD of course not, it's my drive... Quick fix.